### PR TITLE
Use clap beta from crates.io instead of git dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { git = "https://github.com/clap-rs/clap/" }
+clap = "3.0.0-beta.1"


### PR DESCRIPTION
This will allow to publish this crate on `crates.io` itself. Needs a bit more polishing though.